### PR TITLE
Add Cloud, Containers, GitHub Actions Working Group

### DIFF
--- a/active_working_groups.Rmd
+++ b/active_working_groups.Rmd
@@ -22,6 +22,15 @@ please contact the group leader(s).
 - Leads: Levi Waldron, Erica Feick
 - Current Members: Charlotte Soneson, Jenny D, Jenny S, Lori, Marc, Andrew, Daniela, Matt, Mikhail, Samuel, Krithika, Sean, Wes
 
+## Cloud, Container, Github Actions
+
+- Description: The goal of this group is to develop standards, best practices,
+  and tools for the Bioconductor community that are related to the cloud,
+  containers, and GitHub Actions.
+- Slack: #cloud-working-group
+- Leads: Alex Mahmoud, Jen Wokaty
+- Current Members: Levi Waldron, Marcel Ramos, Erdal Cosgun, Sridhar Srivatsan,
+  Brian Schilder, Vince Carey
 
 ## Developers Training
 


### PR DESCRIPTION
We'd like to create a Cloud, Containers, and GitHub Action Working Group. I've added the initial information. From reading the document, it sounds like there is a process to get a working group initialized. Please let us know if there are tasks we need to complete to gain acceptance.