### PR TITLE
Rename Cloud Methods working group

### DIFF
--- a/active_working_groups.Rmd
+++ b/active_working_groups.Rmd
@@ -22,11 +22,10 @@ please contact the group leader(s).
 - Leads: Levi Waldron, Erica Feick
 - Current Members: Charlotte Soneson, Jenny D, Jenny S, Lori, Marc, Andrew, Daniela, Matt, Mikhail, Samuel, Krithika, Sean, Wes
 
-## Cloud, Container, Github Actions
+## Cloud Methods
 
-- Description: The goal of this group is to develop standards, best practices,
-  and tools for the Bioconductor community that are related to the cloud,
-  containers, and GitHub Actions.
+- Description: The goal of this group is to develop standards and tools for the
+  Bioconductor community that are related to the cloud.
 - Slack: #cloud-working-group
 - Leads: Alex Mahmoud, Jen Wokaty
 - Current Members: Levi Waldron, Marcel Ramos, Erdal Cosgun, Sridhar Srivatsan,


### PR DESCRIPTION
I apologize for the multiple PRs. I was reading some of the initial emails about the group and noticed a different, better name was used so I wanted to correct it along with the description.